### PR TITLE
fix: Align version numbers and add Deno compile workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ npx claude-flow@latest init --sparc
 
 ## 🛠️ **Installation & Setup**
 
+> **📋 Prerequisites**: Node.js 18+ or Deno 2.0+  
+> **⚠️ Deno Compile Note**: For Deno 2.1.7+, use `RUST_MIN_STACK=8388608 deno compile` to avoid stack overflow  
+> **📦 Version Note**: npm package (v1.0.65+) may be newer than this source (v1.0.50). See [npm](https://www.npmjs.com/package/claude-flow)
+
 ### **Method 1: Quick Start (Recommended)**
 ```bash
 # Initialize with full SPARC environment
@@ -118,6 +122,12 @@ git clone https://github.com/ruvnet/claude-code-flow.git
 cd claude-code-flow
 deno task build
 ```
+
+> ⚠️ **Deno Compile Workaround**: If using Deno 2.1.7+, set the stack size to avoid compilation errors:
+> ```bash
+> RUST_MIN_STACK=8388608 deno task build
+> # Or directly: RUST_MIN_STACK=8388608 deno compile --allow-all --no-check --output bin/claude-flow src/cli/main.ts
+> ```
 
 ---
 

--- a/deno.json
+++ b/deno.json
@@ -61,7 +61,7 @@
     "lint": "deno lint",
     "fmt": "deno fmt",
     "check": "deno check src/**/*.ts",
-    "build": "deno compile --allow-all --no-check --output bin/claude-flow src/cli/main.ts",
+    "build": "RUST_MIN_STACK=8388608 deno compile --allow-all --no-check --output bin/claude-flow src/cli/main.ts",
     "install": "deno install --allow-all --name claude-flow src/cli/index.ts",
     "clean": "rm -rf test-results coverage bin",
     "ci": "deno fmt --check && deno lint && deno check src/**/*.ts && ./scripts/test-runner.ts --coverage --fail-fast"

--- a/src/cli/cli-core.ts
+++ b/src/cli/cli-core.ts
@@ -8,7 +8,7 @@ import { red, green, yellow, blue, bold, cyan } from "https://deno.land/std@0.22
 import { ensureDir } from "https://deno.land/std@0.224.0/fs/mod.ts";
 import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
 
-export const VERSION = "1.0.43";
+export const VERSION = "1.0.50";
 
 interface CommandContext {
   args: string[];

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,7 +6,7 @@
 import { CLI } from "./cli-core.ts";
 import { setupCommands } from "./commands/index.ts";
 
-const VERSION = "1.0.49";
+const VERSION = "1.0.50";
 
 async function main() {
   const cli = new CLI("claude-flow", "Advanced AI Agent Orchestration System");


### PR DESCRIPTION
## Summary

This PR addresses version inconsistencies and provides a workaround for the Deno compile stack overflow issue affecting versions 2.1.7+.

## Changes

### 1. Version Alignment
- Updated  constants in  and  from 1.0.43/1.0.49 to **1.0.50** to match 
- This ensures consistent version reporting across the application

### 2. Build Process Fix
- Added  to the build task in 
- This fixes the stack overflow error in  for Deno 2.1.7+ (see [related Deno issue](https://github.com/denoland/deno/pull/27721))

### 3. Documentation Updates
- Added warning about Deno compile requirements in README prerequisites
- Documented the version discrepancy between npm (v1.0.65) and source (v1.0.50)
- Provided clear workaround instructions for building with newer Deno versions

## Context

The Deno compile stack overflow is caused by the removal of SWC from denort in Deno 2.1.7. The  environment variable increases the stack size to prevent the overflow.

## Testing

- ✅ Tested compilation with Deno 2.3.6 using the workaround
- ✅ Verified version reporting shows v1.0.50
- ✅ Build process works correctly with the updated deno.json

## Notes

The npm package is currently at v1.0.65, which is 15 versions ahead of this source. This has been documented in the README to avoid confusion.