### PR TITLE
docs: Add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,3 +380,9 @@ npx claude-flow@latest init --sparc
 **Built with ❤️ by [rUv](https://github.com/ruvnet) | Powered by Claude AI**
 
 </div>
+
+---
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=ruvnet/claude-code-flow&type=Date)](https://www.star-history.com/#ruvnet/claude-code-flow&Date)


### PR DESCRIPTION
This PR adds a "Star History" section to the README.md file. This section includes a dynamic SVG chart that visualizes the repository's star growth over time, providing a nice visual metric for community engagement.